### PR TITLE
Reducing PolarSSL config.h

### DIFF
--- a/include/ccoin/key.h
+++ b/include/ccoin/key.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <glib.h>
 #include <polarssl/entropy.h>
-#include <polarssl/ctr_drbg.h>
+#include <polarssl/hmac_drbg.h>
 #include <polarssl/pk.h>
 #include <ccoin/buint.h>
 
@@ -18,7 +18,7 @@
 struct bp_key {
 	pk_context pk;
 	entropy_context e;
-	ctr_drbg_context c;
+	hmac_drbg_context c;
 };
 
 extern bool bp_key_init(struct bp_key *key);

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -1312,7 +1312,7 @@
  *
  * This module provides the CTR_DRBG AES-256 random number generator.
  */
-#define POLARSSL_CTR_DRBG_C
+//#define POLARSSL_CTR_DRBG_C
 
 /**
  * \def POLARSSL_DEBUG_C

--- a/src/brd.c
+++ b/src/brd.c
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <polarssl/entropy.h>
-#include <polarssl/ctr_drbg.h>
+#include <polarssl/hmac_drbg.h>
 #include <event2/event.h>
 #include <ccoin/core.h>
 #include <ccoin/util.h>
@@ -1637,7 +1637,7 @@ static void shutdown_daemon(struct net_child_info *nci)
 
 static int rand_bytes(unsigned char *buf, int num)
 {
-	ctr_drbg_context ctr_drbg;
+	hmac_drbg_context hmac_drbg;
 	entropy_context entropy;
 
 	/* TODO: Add a more random personalised string */
@@ -1645,14 +1645,15 @@ static int rand_bytes(unsigned char *buf, int num)
 	int ret = 0;
 
 	entropy_init(&entropy);
-	if ((ret = ctr_drbg_init(&ctr_drbg, entropy_func, &entropy,
+	if ((ret = hmac_drbg_init(&hmac_drbg, md_info_from_type(POLARSSL_MD_SHA1),
+					entropy_func, &entropy,
 					(unsigned char *) pers, strlen(pers))) != 0 ) {
-		fprintf(stderr, "rand_bytes: ctr_drbg_init returned -0x%04x\n", -ret);
+		fprintf(stderr, "rand_bytes: hmac_drbg_init returned -0x%04x\n", -ret);
 		goto out;
 	}
 
-	if ((ret = ctr_drbg_random(&ctr_drbg, buf, num)) != 0 ) {
-		fprintf(stderr, "rand_bytes: ctr_drbg_random returned -0x%04x\n", -ret);
+	if ((ret = hmac_drbg_random(&hmac_drbg, buf, num)) != 0 ) {
+		fprintf(stderr, "rand_bytes: hmac_drbg_random returned -0x%04x\n", -ret);
 		goto out;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,7 @@
 #include <ctype.h>
 #include <glib.h>
 #include <polarssl/entropy.h>
-#include <polarssl/ctr_drbg.h>
+#include <polarssl/hmac_drbg.h>
 #include "picocoin.h"
 #include <ccoin/coredefs.h>
 #include "wallet.h"
@@ -309,7 +309,7 @@ static bool do_command(const char *s)
 
 static int rand_bytes(unsigned char *buf, int num)
 {
-	ctr_drbg_context ctr_drbg;
+	hmac_drbg_context hmac_drbg;
 	entropy_context entropy;
 
 	/* TODO: Add a more random personalised string */
@@ -317,14 +317,15 @@ static int rand_bytes(unsigned char *buf, int num)
 	int ret = 0;
 
 	entropy_init(&entropy);
-	if ((ret = ctr_drbg_init(&ctr_drbg, entropy_func, &entropy,
+	if ((ret = hmac_drbg_init(&hmac_drbg, md_info_from_type(POLARSSL_MD_SHA1),
+					entropy_func, &entropy,
 					(unsigned char *) pers, strlen(pers))) != 0 ) {
-		fprintf(stderr, "rand_bytes: ctr_drbg_init returned -0x%04x\n", -ret);
+		fprintf(stderr, "rand_bytes: hmac_drbg_init returned -0x%04x\n", -ret);
 		goto out;
 	}
 
-	if ((ret = ctr_drbg_random(&ctr_drbg, buf, num)) != 0 ) {
-		fprintf(stderr, "rand_bytes: ctr_drbg_random returned -0x%04x\n", -ret);
+	if ((ret = hmac_drbg_random(&hmac_drbg, buf, num)) != 0 ) {
+		fprintf(stderr, "rand_bytes: hmac_drbg_random returned -0x%04x\n", -ret);
 		goto out;
 	}
 


### PR DESCRIPTION
Hey,

Here are two commits that reduce the footprint of PolarSSL in picocoin a bit more. The first one just disables some things that are apparently not needed (`make && make check` working fine without them, but I couldn't try the `chain-verf` test), and the second changes a bit of code to get rid of ctr_drbg: since you need hmac_drbg for deterministic ECDSA anyway, it seemed better not to use a second drbg in addition.

With PolarSSL 1.3.8 (out soon), you should also be able to disable `POLARSSL_X509_USE_C` and `POLARSSL_X509_CRT_PARSE_C`, which is currently not possible due to a missing dependency declaration in our test suite.

Also, I left `DES_C` and `MD5_C` since they were sometimes used for encrypted private keys in PEM format, but that's probably something you can get disable too unless you known you'll be using such keys. (I'm not even sure if private key are stored in the standard PEM formats in bitcoin: if you don't use `pk_parse_key()` to read them, it means they're not, and you can get rid of `DES_C` and `MD5_C` unless you know you need them for another reason.) (At least there is nothing in PEM format in the repo except for some PolarSSL test files, according to `grep -R --exclude-dir=.git --exclude-dir=polarssl -- '-----BEGIN' .`.)
